### PR TITLE
Improve diff and merge tools

### DIFF
--- a/dot_config/chezmoi/chezmoi.toml
+++ b/dot_config/chezmoi/chezmoi.toml
@@ -3,8 +3,9 @@ name = "{{ (gh auth status --show-token | grep -oP '(?<=Logged in to github.com 
 email = "{{ (gh api user | jq -r '.email') }}"
 
 [diff]
-command = "difft"
+command = "/opt/homebrew/bin/difft"
 args = ["--display=inline", "--color=always", "{{.Destination}}", "{{.Target}}"]
 
 [merge]
-command = "vimdiff"
+command = "nvim"
+args = ["-f", "-c", "Gvdiffsplit! {{.Destination}} {{.Target}}", "{{.Source}}"]

--- a/dot_config/fish/functions/chezmoi_fugdiff.fish
+++ b/dot_config/fish/functions/chezmoi_fugdiff.fish
@@ -1,0 +1,13 @@
+function chezmoi_fugdiff
+    set target $argv
+    if test -z "$target"
+        echo "Usage: chezmoi_fugdiff <file>"
+        return 1
+    end
+
+    # Get the target path in the source state
+    set source_path (chezmoi source-path $target)
+
+    # Open nvim with fugitive diff
+    nvim -c "Gvdiffsplit $target" $source_path
+end

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -18,8 +18,8 @@
     symlinks = true
     # Ensure proper quoting of file names
     quotepath = false
-    # Use simple cat as pager for maximum terminal compatibility
-    pager = cat
+    # Use bat as pager (your preferred tool)
+    pager = "bat --style=plain"
     # Store global exclusions
     excludesfile = ~/.gitignore_global
     # Store global attributes
@@ -83,15 +83,16 @@
     ui = auto
 
 [diff]
-    # Use difftastic for all diffs by default if available
-    external = "command -v difft >/dev/null 2>&1 && difft --display=inline \"$@\" || git diff"
-    tool = difftastic
-    # Add VSCode as an alternative diff tool
-    guitool = vscode
-    # Use inline diff format
-    colorMoved = default
     # Use histogram algorithm for better diffs
     algorithm = histogram
+    # Use inline diff format
+    colorMoved = default
+    # Add VSCode as an alternative diff tool
+    guitool = vscode
+    # Make difftastic the default external diff tool
+    external = difft
+    # Set difftastic as the default diff tool
+    tool = difftastic
 
 [difftool "difftastic"]
     cmd = difft --display=inline "$LOCAL" "$REMOTE"
@@ -103,11 +104,10 @@
     prompt = false
 
 [pager]
-    # Disable paging completely for better terminal compatibility
-    diff = false
-    show = false
-    log = false
-    # Always use a pager for difftool
+    # Use bat with proper flags for difftastic output
+    diff = "bat --style=plain"
+    show = "bat --style=plain"
+    log = "bat --style=plain"
     difftool = true
 
 [merge]
@@ -153,6 +153,11 @@
     autocorrect = 10
 
 [alias]
+    # Use difftastic for diffs (recommended method)
+    dft = "!f() { GIT_EXTERNAL_DIFF=difft git diff $@; }; f"
+    dlog = "!f() { GIT_EXTERNAL_DIFF=difft git log -p $@; }; f"
+    dshow = "!f() { GIT_EXTERNAL_DIFF=difft git show $@; }; f"
+
     # Shorter status command
     st = status
     # Shorter checkout command
@@ -189,10 +194,6 @@
     discard = reset --hard
     # List contributors with number of commits
     contributors = shortlog --summary --numbered
-    # Use difftastic for viewing changes
-    dft = difftool
-    # Difftastic log for showing changes with syntax highlighting
-    difflog = "ll -p --ext-diff"
     # Use VSCode for viewing changes
     vsdiff = difftool --tool=vscode
     # Use VSCode for resolving merge conflicts
@@ -201,8 +202,6 @@
     nvimmerge = mergetool --tool=nvim
     # Use fugitive for resolving merge conflicts
     fugmerge = mergetool --tool=fugitive
-    # Show diff using difftastic with fallback to standard git log
-    dlog = "!f() { if command -v difft >/dev/null 2>&1; then GIT_EXTERNAL_DIFF=difft git log -p --ext-diff $@; else git log -p $@; fi; }; f"
 
 [credential]
     # Cache credentials for 1 hour (3600 seconds)


### PR DESCRIPTION
This PR improves the configuration of diff and merge tools:\n\n- Adds a fish helper function to use fugitive with chezmoi diffs\n- Updates chezmoi merge configuration to use Neovim with fugitive\n- Improves Git configuration to properly use difftastic as the default diff tool\n\nThese changes ensure a consistent experience when working with diffs and merges across both Git and chezmoi.