### PR TITLE
Fix: Make gitconfig email template more robust with hasKey check

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -5,7 +5,7 @@
 
 [user]
     name = # [[ .name ]] #
-# [[ if ne .email "" ]] #
+# [[ if (hasKey . "email") ]] #
     email = # [[ .email ]] #
 # [[ end ]] #
 


### PR DESCRIPTION
This PR fixes an issue where chezmoi apply fails with 'map has no entry for key email' error when the email is not available in the data. The fix uses hasKey to check if the email field exists before trying to use it.